### PR TITLE
Add `Hopper` to the list of grain libaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 ## Libraries
 
-- [alex-snezhko/hopper](https://github.com/alex-snezhko/hopper) - A An HTTP microframework for the Grain programming language built on top of Wagi
+- [alex-snezhko/hopper](https://github.com/alex-snezhko/hopper) - An HTTP microframework for the Grain programming language built on top of Wagi
 
 ## Contribute
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 ## Libraries
 
-- [alex-snezhko/hopper](https://github.com/alex-snezhko/hopper) - An HTTP microframework for the Grain programming language built on top of Wagi
+- [Hopper](https://github.com/alex-snezhko/hopper) - An HTTP microframework for the Grain programming language built on top of WAGI
 
 ## Contribute
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@
 ## Applications
 
 - [deislabs/wagi-fileserver](https://github.com/deislabs/wagi-fileserver) — A static file server for Wagi
-- [alex-snezhko/hopper](https://github.com/alex-snezhko/hopper) - A An HTTP microframework for the Grain programming language built on top of Wagi
 
 ## Libraries
+
+- [alex-snezhko/hopper](https://github.com/alex-snezhko/hopper) - A An HTTP microframework for the Grain programming language built on top of Wagi
 
 ## Contribute
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 ## Applications
 
 - [deislabs/wagi-fileserver](https://github.com/deislabs/wagi-fileserver) — A static file server for Wagi
+- [alex-snezhko/hopper](https://github.com/alex-snezhko/hopper) - A An HTTP microframework for the Grain programming language built on top of Wagi
 
 ## Libraries
 


### PR DESCRIPTION
Add hopper https://github.com/alex-snezhko/hopper/tree/main to the list of grain libaries.