### PR TITLE
feat: Add grain-midi & grain-toml libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@
 ## Libraries
 
 - [Hopper](https://github.com/alex-snezhko/hopper) - An HTTP microframework for the Grain programming language built on top of WAGI
-- [Grain-Midi](https://github.com/spotandjake/Grain-Midi) - A feature-complete MIDI decode for teh Grain programming language
-- [Grain-Toml](https://github.com/spotandjake/Grain-Toml) - A feature-complete Toml Parser for the Grina programming language
+- [Grain-Midi](https://github.com/spotandjake/Grain-Midi) - A MIDI decoder for the Grain programming language
+- [Grain-Toml](https://github.com/spotandjake/Grain-Toml) - A Grain toml parsing library that complies with the `v1.1.0` spec
 
 ## Contribute
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@
 ## Libraries
 
 - [Hopper](https://github.com/alex-snezhko/hopper) - An HTTP microframework for the Grain programming language built on top of WAGI
+- [Grain-Midi](https://github.com/spotandjake/Grain-Midi) - A feature-complete MIDI decode for teh Grain programming language
+- [Grain-Toml](https://github.com/spotandjake/Grain-Toml) - A feature-complete Toml Parser for the Grina programming language
 
 ## Contribute
 


### PR DESCRIPTION
This pr adds `Grain-midi` & `Grain-toml` to the library section, just to show off some more real world code & provide two useful parsers to the ecosystem.